### PR TITLE
fix: Wrong base branch of renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "labels": ["dependencies"],
-  "baseBranches": ["develop"],
+  "baseBranches": ["master"],
   "commitBodyTable": true,
   "commitMessagePrefix": "chore(deps)"
 }


### PR DESCRIPTION
## Describe your changes

Base branch was develop, but this branch no longer exists (#83). So replace it by master.

## Related issue reference

Closes #85