### PR TITLE
fix: Calcul is wrongly parsed when no spaces

### DIFF
--- a/src/grammar/FilLexer.g4
+++ b/src/grammar/FilLexer.g4
@@ -32,6 +32,7 @@ FALSE: 'false';
 // Operators
 EQ: '=';
 COLON: ':';
+SEMI: ';';
 PLUS: '+';
 MINUS: '-';
 STAR: '*';
@@ -68,9 +69,8 @@ CHARACTER: '\'' (~('\'' | '\\' | '\n') | ESCAPE_CHAR) '\'';
 
 // Numbers
 fragment DIGIT: [0-9];
-fragment SIGN: '+'|'-';
-INTEGER: SIGN? DIGIT+;
-FLOAT: SIGN? DIGIT* '.' DIGIT+;
+INTEGER: DIGIT+;
+FLOAT: DIGIT* '.' DIGIT+;
 
 IDENTIFIER: (LETTER | '_') (LETTER | DIGIT | '_')*;
 

--- a/src/grammar/FilParser.g4
+++ b/src/grammar/FilParser.g4
@@ -48,7 +48,7 @@ program returns[std::shared_ptr<filc::Program> tree]
 }
     : (e=expression {
         expressions.push_back($e.tree);
-    })* EOF;
+    } SEMI?)* EOF;
 
 expression returns[std::shared_ptr<filc::Expression> tree]
 @after {
@@ -112,12 +112,25 @@ boolean returns[std::shared_ptr<filc::BooleanLiteral> tree]
     };
 
 number returns[std::shared_ptr<filc::Expression> tree]
-    : i=INTEGER {
-        $tree = std::make_shared<filc::IntegerLiteral>(stoi($i.text));
+@init {
+    bool is_negative = false;
+}
+    : (PLUS | MINUS {
+        is_negative = true;
+    })? (i=INTEGER {
+        auto ivalue = stoi($i.text);
+        if (is_negative) {
+            ivalue = -ivalue;
+        }
+        $tree = std::make_shared<filc::IntegerLiteral>(ivalue);
     }
     | f=FLOAT {
-        $tree = std::make_shared<filc::FloatLiteral>(stod($f.text));
-    };
+        auto fvalue = stod($f.text);
+        if (is_negative) {
+            fvalue = -fvalue;
+        }
+        $tree = std::make_shared<filc::FloatLiteral>(fvalue);
+    });
 
 variable_declaration returns[std::shared_ptr<filc::VariableDeclaration> tree]
 @init {

--- a/tests/unit/grammar/calcul/BinaryCalculTest.cpp
+++ b/tests/unit/grammar/calcul/BinaryCalculTest.cpp
@@ -34,15 +34,32 @@ TEST(BinaryCalcul, parsingAddition) {
     const auto program     = parseString("1 + 2");
     const auto expressions = program->getExpressions();
     ASSERT_THAT(expressions, SizeIs(1));
-    auto calcul = std::dynamic_pointer_cast<filc::BinaryCalcul>(expressions[0]);
+    const auto calcul = std::dynamic_pointer_cast<filc::BinaryCalcul>(expressions[0]);
     ASSERT_NE(nullptr, calcul);
     ASSERT_STREQ("+", calcul->getOperator().c_str());
     ASSERT_NE(nullptr, calcul->getLeftExpression());
     ASSERT_NE(nullptr, calcul->getRightExpression());
-    auto left = std::dynamic_pointer_cast<filc::IntegerLiteral>(calcul->getLeftExpression());
+    const auto left = std::dynamic_pointer_cast<filc::IntegerLiteral>(calcul->getLeftExpression());
     ASSERT_NE(nullptr, left);
     ASSERT_EQ(1, left->getValue());
-    auto right = std::dynamic_pointer_cast<filc::IntegerLiteral>(calcul->getRightExpression());
+    const auto right = std::dynamic_pointer_cast<filc::IntegerLiteral>(calcul->getRightExpression());
+    ASSERT_NE(nullptr, right);
+    ASSERT_EQ(2, right->getValue());
+}
+
+TEST(BinaryCalcul, parsingAdditionGlued) { // issue #47
+    const auto program     = parseString("1+2");
+    const auto expressions = program->getExpressions();
+    ASSERT_THAT(expressions, SizeIs(1));
+    const auto calcul = std::dynamic_pointer_cast<filc::BinaryCalcul>(expressions[0]);
+    ASSERT_NE(nullptr, calcul);
+    ASSERT_STREQ("+", calcul->getOperator().c_str());
+    ASSERT_NE(nullptr, calcul->getLeftExpression());
+    ASSERT_NE(nullptr, calcul->getRightExpression());
+    const auto left = std::dynamic_pointer_cast<filc::IntegerLiteral>(calcul->getLeftExpression());
+    ASSERT_NE(nullptr, left);
+    ASSERT_EQ(1, left->getValue());
+    const auto right = std::dynamic_pointer_cast<filc::IntegerLiteral>(calcul->getRightExpression());
     ASSERT_NE(nullptr, right);
     ASSERT_EQ(2, right->getValue());
 }

--- a/tests/unit/grammar/literal/FloatLiteralTest.cpp
+++ b/tests/unit/grammar/literal/FloatLiteralTest.cpp
@@ -33,7 +33,7 @@ TEST(FloatLiteral, parsingFullFloat) {
     const auto program     = parseString("3.14");
     const auto expressions = program->getExpressions();
     ASSERT_THAT(expressions, SizeIs(1));
-    auto literal = std::dynamic_pointer_cast<filc::FloatLiteral>(expressions[0]);
+    const auto literal = std::dynamic_pointer_cast<filc::FloatLiteral>(expressions[0]);
     ASSERT_NE(nullptr, literal);
     ASSERT_EQ(3.14, literal->getValue());
 }
@@ -42,7 +42,19 @@ TEST(FloatLiteral, parsingSemiFloat) {
     const auto program     = parseString(".2");
     const auto expressions = program->getExpressions();
     ASSERT_THAT(expressions, SizeIs(1));
-    auto literal = std::dynamic_pointer_cast<filc::FloatLiteral>(expressions[0]);
+    const auto literal = std::dynamic_pointer_cast<filc::FloatLiteral>(expressions[0]);
     ASSERT_NE(nullptr, literal);
     ASSERT_EQ(.2, literal->getValue());
+}
+
+TEST(FloatLiteral, parsingSigned) {
+    const auto program     = parseString("-3.14;+0.2");
+    const auto expressions = program->getExpressions();
+    ASSERT_THAT(expressions, SizeIs(2));
+    const auto literal1 = std::dynamic_pointer_cast<filc::FloatLiteral>(expressions[0]);
+    ASSERT_NE(nullptr, literal1);
+    ASSERT_EQ(-3.14, literal1->getValue());
+    const auto literal2 = std::dynamic_pointer_cast<filc::FloatLiteral>(expressions[1]);
+    ASSERT_NE(nullptr, literal2);
+    ASSERT_EQ(.2, literal2->getValue());
 }

--- a/tests/unit/grammar/literal/IntegerLiteralTest.cpp
+++ b/tests/unit/grammar/literal/IntegerLiteralTest.cpp
@@ -33,7 +33,19 @@ TEST(IntegerLiteral, parsing) {
     const auto program     = parseString("73");
     const auto expressions = program->getExpressions();
     ASSERT_THAT(expressions, SizeIs(1));
-    auto literal = std::dynamic_pointer_cast<filc::IntegerLiteral>(expressions[0]);
+    const auto literal = std::dynamic_pointer_cast<filc::IntegerLiteral>(expressions[0]);
     ASSERT_NE(nullptr, literal);
     ASSERT_EQ(73, literal->getValue());
+}
+
+TEST(IntegerLiteral, parsingSigned) {
+    const auto program     = parseString("-2;+2");
+    const auto expressions = program->getExpressions();
+    ASSERT_THAT(expressions, SizeIs(2));
+    const auto literal1 = std::dynamic_pointer_cast<filc::IntegerLiteral>(expressions[0]);
+    ASSERT_NE(nullptr, literal1);
+    ASSERT_EQ(-2, literal1->getValue());
+    const auto literal2 = std::dynamic_pointer_cast<filc::IntegerLiteral>(expressions[1]);
+    ASSERT_NE(nullptr, literal2);
+    ASSERT_EQ(2, literal2->getValue());
 }


### PR DESCRIPTION
Closes #47

Note: Add possibility to write ; to separate expressions

*Testing:*

1+2 should be parsed as a calcul and not 1 then +2