### PR TITLE
feat: Pointer initialization

### DIFF
--- a/include/filc/grammar/DumpVisitor.h
+++ b/include/filc/grammar/DumpVisitor.h
@@ -56,6 +56,8 @@ class DumpVisitor final: public Visitor<void> {
 
     auto visitPointerDereferencing(PointerDereferencing *pointer) -> void override;
 
+    auto visitVariableAddress(VariableAddress *address) -> void override;
+
   private:
     std::ostream &_out;
     int _indent_level;

--- a/include/filc/grammar/DumpVisitor.h
+++ b/include/filc/grammar/DumpVisitor.h
@@ -54,6 +54,8 @@ class DumpVisitor final: public Visitor<void> {
 
     auto visitPointer(Pointer *pointer) -> void override;
 
+    auto visitPointerDereferencing(PointerDereferencing *pointer) -> void override;
+
   private:
     std::ostream &_out;
     int _indent_level;

--- a/include/filc/grammar/Type.h
+++ b/include/filc/grammar/Type.h
@@ -41,10 +41,12 @@ class AbstractType {
 
     auto setLLVMType(llvm::Type *type) -> void;
 
-    [[nodiscard]] auto getLLVMType() const -> llvm::Type *;
+    [[nodiscard]] auto getLLVMType(llvm::LLVMContext *context) -> llvm::Type *;
 
   protected:
     AbstractType() = default;
+
+    virtual auto generateLLVMType(llvm::LLVMContext *context) -> void = 0;
 
   private:
     llvm::Type *_llvm_type = nullptr;
@@ -60,6 +62,8 @@ class Type final : public AbstractType {
 
     [[nodiscard]] auto toDisplay() const noexcept -> std::string override;
 
+    auto generateLLVMType(llvm::LLVMContext *context) -> void override;
+
   private:
     std::string _name;
 };
@@ -74,6 +78,10 @@ class PointerType final : public AbstractType {
 
     [[nodiscard]] auto toDisplay() const noexcept -> std::string override;
 
+    [[nodiscard]] auto getPointedType() const noexcept -> std::shared_ptr<AbstractType>;
+
+    auto generateLLVMType(llvm::LLVMContext *context) -> void override;
+
   private:
     std::shared_ptr<AbstractType> _pointed_type;
 };
@@ -87,6 +95,8 @@ class AliasType final : public AbstractType {
     [[nodiscard]] auto getDisplayName() const noexcept -> std::string override;
 
     [[nodiscard]] auto toDisplay() const noexcept -> std::string override;
+
+    auto generateLLVMType(llvm::LLVMContext *context) -> void override;
 
   private:
     std::string _name;

--- a/include/filc/grammar/Visitor.h
+++ b/include/filc/grammar/Visitor.h
@@ -57,6 +57,8 @@ template<typename Return> class Visitor {
 
     virtual auto visitPointerDereferencing(PointerDereferencing *pointer) -> Return = 0;
 
+    virtual auto visitVariableAddress(VariableAddress *address) -> Return = 0;
+
   protected:
     Visitor() = default;
 };

--- a/include/filc/grammar/Visitor.h
+++ b/include/filc/grammar/Visitor.h
@@ -55,6 +55,8 @@ template<typename Return> class Visitor {
 
     virtual auto visitPointer(Pointer *pointer) -> Return = 0;
 
+    virtual auto visitPointerDereferencing(PointerDereferencing *pointer) -> Return = 0;
+
   protected:
     Visitor() = default;
 };

--- a/include/filc/grammar/Visitor.h
+++ b/include/filc/grammar/Visitor.h
@@ -53,6 +53,8 @@ template<typename Return> class Visitor {
 
     virtual auto visitAssignation(Assignation *assignation) -> Return = 0;
 
+    virtual auto visitPointer(Pointer *pointer) -> Return = 0;
+
   protected:
     Visitor() = default;
 };

--- a/include/filc/grammar/ast.h
+++ b/include/filc/grammar/ast.h
@@ -49,6 +49,8 @@ class Identifier;
 class BinaryCalcul;
 
 class Assignation;
+
+class Pointer;
 }
 
 #endif // FILC_AST_H

--- a/include/filc/grammar/ast.h
+++ b/include/filc/grammar/ast.h
@@ -51,6 +51,8 @@ class BinaryCalcul;
 class Assignation;
 
 class Pointer;
+
+class PointerDereferencing;
 }
 
 #endif // FILC_AST_H

--- a/include/filc/grammar/pointer/Pointer.h
+++ b/include/filc/grammar/pointer/Pointer.h
@@ -21,45 +21,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef FILC_DUMPVISITOR_H
-#define FILC_DUMPVISITOR_H
+#ifndef FILC_POINTER_H
+#define FILC_POINTER_H
 
-#include "filc/grammar/Visitor.h"
-#include <iostream>
+#include "filc/grammar/expression/Expression.h"
+
+#include <memory>
+#include <string>
 
 namespace filc {
-class DumpVisitor final: public Visitor<void> {
+class Pointer final : public Expression {
   public:
-    explicit DumpVisitor(std::ostream &out);
+    Pointer(std::string type_name, const std::shared_ptr<Expression> &value);
 
-    auto visitProgram(Program *program) -> void override;
+    [[nodiscard]] auto getTypeName() const -> std::string;
 
-    auto visitBooleanLiteral(BooleanLiteral *literal) -> void override;
+    [[nodiscard]] auto getValue() const -> std::shared_ptr<Expression>;
 
-    auto visitIntegerLiteral(IntegerLiteral *literal) -> void override;
+    [[nodiscard]] auto getPointedType() const -> std::shared_ptr<AbstractType>;
 
-    auto visitFloatLiteral(FloatLiteral *literal) -> void override;
+    auto acceptVoidVisitor(Visitor<void> *visitor) -> void override;
 
-    auto visitCharacterLiteral(CharacterLiteral *literal) -> void override;
-
-    auto visitStringLiteral(StringLiteral *literal) -> void override;
-
-    auto visitVariableDeclaration(VariableDeclaration *variable) -> void override;
-
-    auto visitIdentifier(Identifier *identifier) -> void override;
-
-    auto visitBinaryCalcul(BinaryCalcul *calcul) -> void override;
-
-    auto visitAssignation(Assignation *assignation) -> void override;
-
-    auto visitPointer(Pointer *pointer) -> void override;
+    auto acceptIRVisitor(Visitor<llvm::Value *> *visitor) -> llvm::Value * override;
 
   private:
-    std::ostream &_out;
-    int _indent_level;
-
-    auto printIdent() const -> void;
+    std::string _type_name;
+    std::shared_ptr<Expression> _value;
 };
-}
+} // namespace filc
 
-#endif // FILC_DUMPVISITOR_H
+#endif // FILC_POINTER_H

--- a/include/filc/grammar/pointer/Pointer.h
+++ b/include/filc/grammar/pointer/Pointer.h
@@ -62,6 +62,20 @@ class PointerDereferencing final : public Expression {
   private:
     std::string _name;
 };
+
+class VariableAddress final : public Expression {
+  public:
+    explicit VariableAddress(std::string name);
+
+    [[nodiscard]] auto getName() const -> std::string;
+
+    auto acceptVoidVisitor(Visitor<void> *visitor) -> void override;
+
+    auto acceptIRVisitor(Visitor<llvm::Value *> *visitor) -> llvm::Value * override;
+
+  private:
+    std::string _name;
+};
 } // namespace filc
 
 #endif // FILC_POINTER_H

--- a/include/filc/grammar/pointer/Pointer.h
+++ b/include/filc/grammar/pointer/Pointer.h
@@ -48,6 +48,20 @@ class Pointer final : public Expression {
     std::string _type_name;
     std::shared_ptr<Expression> _value;
 };
+
+class PointerDereferencing final : public Expression {
+  public:
+    explicit PointerDereferencing(std::string name);
+
+    [[nodiscard]] auto getName() const -> std::string;
+
+    auto acceptVoidVisitor(Visitor<void> *visitor) -> void override;
+
+    auto acceptIRVisitor(Visitor<llvm::Value *> *visitor) -> llvm::Value * override;
+
+  private:
+    std::string _name;
+};
 } // namespace filc
 
 #endif // FILC_POINTER_H

--- a/include/filc/llvm/GeneratorContext.h
+++ b/include/filc/llvm/GeneratorContext.h
@@ -21,36 +21,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef FILC_NAME_H
-#define FILC_NAME_H
 
-#include "filc/grammar/Type.h"
+#ifndef GENERATORCONTEXT_H
+#define GENERATORCONTEXT_H
+
+#include <llvm/IR/IRBuilder.h>
+#include <map>
 #include <string>
-#include <memory>
 
 namespace filc {
-class Name {
+class GeneratorContext {
   public:
-    Name();
+    GeneratorContext();
 
-    Name(bool constant, std::string name, std::shared_ptr<AbstractType> type, bool has_value);
+    auto setValue(const std::string &name, llvm::Value *value) -> void;
 
-    [[nodiscard]] auto isConstant() const -> bool;
-
-    [[nodiscard]] auto hasValue() const -> bool;
-
-    [[nodiscard]] auto getName() const -> const std::string&;
-
-    [[nodiscard]] auto getType() const -> std::shared_ptr<AbstractType>;
-
-    auto hasValue(bool has_value) -> void;
+    [[nodiscard]] auto getValue(const std::string &name) const -> llvm::Value *;
 
   private:
-    bool _constant;
-    bool _has_value;
-    std::string _name;
-    std::shared_ptr<AbstractType> _type;
+    std::map<std::string, llvm::Value *> _values;
 };
-}
+} // namespace filc
 
-#endif // FILC_NAME_H
+#endif // GENERATORCONTEXT_H

--- a/include/filc/llvm/IRGenerator.h
+++ b/include/filc/llvm/IRGenerator.h
@@ -64,6 +64,8 @@ class IRGenerator final: public Visitor<llvm::Value *> {
 
     auto visitPointer(Pointer *pointer) -> llvm::Value * override;
 
+    auto visitPointerDereferencing(PointerDereferencing *pointer) -> llvm::Value * override;
+
   private:
     std::unique_ptr<llvm::LLVMContext> _llvm_context;
     std::unique_ptr<llvm::Module> _module;

--- a/include/filc/llvm/IRGenerator.h
+++ b/include/filc/llvm/IRGenerator.h
@@ -61,6 +61,8 @@ class IRGenerator final: public Visitor<llvm::Value *> {
 
     auto visitAssignation(Assignation *assignation) -> llvm::Value * override;
 
+    auto visitPointer(Pointer *pointer) -> llvm::Value * override;
+
   private:
     std::unique_ptr<llvm::LLVMContext> _llvm_context;
     std::unique_ptr<llvm::Module> _module;

--- a/include/filc/llvm/IRGenerator.h
+++ b/include/filc/llvm/IRGenerator.h
@@ -66,6 +66,8 @@ class IRGenerator final: public Visitor<llvm::Value *> {
 
     auto visitPointerDereferencing(PointerDereferencing *pointer) -> llvm::Value * override;
 
+    auto visitVariableAddress(VariableAddress *address) -> llvm::Value * override;
+
   private:
     std::unique_ptr<llvm::LLVMContext> _llvm_context;
     std::unique_ptr<llvm::Module> _module;

--- a/include/filc/llvm/IRGenerator.h
+++ b/include/filc/llvm/IRGenerator.h
@@ -26,6 +26,7 @@
 
 #include "filc/grammar/Visitor.h"
 #include "filc/validation/Environment.h"
+#include "filc/llvm/GeneratorContext.h"
 #include <llvm/IR/Module.h>
 #include <llvm/IR/IRBuilder.h>
 #include <memory>
@@ -67,6 +68,7 @@ class IRGenerator final: public Visitor<llvm::Value *> {
     std::unique_ptr<llvm::LLVMContext> _llvm_context;
     std::unique_ptr<llvm::Module> _module;
     std::unique_ptr<llvm::IRBuilder<>> _builder;
+    GeneratorContext _context;
 };
 }
 

--- a/include/filc/validation/Environment.h
+++ b/include/filc/validation/Environment.h
@@ -48,6 +48,8 @@ class Environment {
 
     auto addName(const Name &name) -> void;
 
+    auto setName(const Name &name) -> void;
+
   private:
     std::map<std::string, std::shared_ptr<AbstractType>> _types;
     std::map<std::string, Name> _names;

--- a/include/filc/validation/ValidationVisitor.h
+++ b/include/filc/validation/ValidationVisitor.h
@@ -90,6 +90,8 @@ class ValidationVisitor final : public Visitor<void> {
 
     auto visitAssignation(Assignation *assignation) -> void override;
 
+    auto visitPointer(Pointer *pointer) -> void override;
+
   private:
     std::unique_ptr<ValidationContext> _context;
     std::unique_ptr<Environment> _environment;

--- a/include/filc/validation/ValidationVisitor.h
+++ b/include/filc/validation/ValidationVisitor.h
@@ -92,6 +92,8 @@ class ValidationVisitor final : public Visitor<void> {
 
     auto visitPointer(Pointer *pointer) -> void override;
 
+    auto visitPointerDereferencing(PointerDereferencing *pointer) -> void override;
+
   private:
     std::unique_ptr<ValidationContext> _context;
     std::unique_ptr<Environment> _environment;

--- a/include/filc/validation/ValidationVisitor.h
+++ b/include/filc/validation/ValidationVisitor.h
@@ -94,6 +94,8 @@ class ValidationVisitor final : public Visitor<void> {
 
     auto visitPointerDereferencing(PointerDereferencing *pointer) -> void override;
 
+    auto visitVariableAddress(VariableAddress *address) -> void override;
+
   private:
     std::unique_ptr<ValidationContext> _context;
     std::unique_ptr<Environment> _environment;

--- a/src/grammar/DumpVisitor.cpp
+++ b/src/grammar/DumpVisitor.cpp
@@ -153,6 +153,11 @@ auto DumpVisitor::visitPointer(Pointer *pointer) -> void {
     _indent_level--;
 }
 
+auto DumpVisitor::visitPointerDereferencing(PointerDereferencing *pointer) -> void {
+    printIdent();
+    _out << "[PointerDereferencing:" << pointer->getName() << "]\n";
+}
+
 auto DumpVisitor::printIdent() const -> void {
     _out << std::string(_indent_level, '\t');
 }

--- a/src/grammar/DumpVisitor.cpp
+++ b/src/grammar/DumpVisitor.cpp
@@ -158,6 +158,11 @@ auto DumpVisitor::visitPointerDereferencing(PointerDereferencing *pointer) -> vo
     _out << "[PointerDereferencing:" << pointer->getName() << "]\n";
 }
 
+auto DumpVisitor::visitVariableAddress(VariableAddress *address) -> void {
+    printIdent();
+    _out << "[VariableAddress:" << address->getName() << "]\n";
+}
+
 auto DumpVisitor::printIdent() const -> void {
     _out << std::string(_indent_level, '\t');
 }

--- a/src/grammar/DumpVisitor.cpp
+++ b/src/grammar/DumpVisitor.cpp
@@ -27,6 +27,7 @@
 #include "filc/grammar/calcul/Calcul.h"
 #include "filc/grammar/identifier/Identifier.h"
 #include "filc/grammar/literal/Literal.h"
+#include "filc/grammar/pointer/Pointer.h"
 #include "filc/grammar/program/Program.h"
 #include "filc/grammar/variable/Variable.h"
 
@@ -141,6 +142,14 @@ auto DumpVisitor::visitAssignation(Assignation *assignation) -> void {
     _out << "[Assignation:" << assignation->getIdentifier() << "]\n";
     _indent_level++;
     assignation->getValue()->acceptVoidVisitor(this);
+    _indent_level--;
+}
+
+auto DumpVisitor::visitPointer(Pointer *pointer) -> void {
+    printIdent();
+    _out << "[Pointer:" << pointer->getTypeName() << "]\n";
+    _indent_level++;
+    pointer->getValue()->acceptVoidVisitor(this);
     _indent_level--;
 }
 

--- a/src/grammar/FilLexer.g4
+++ b/src/grammar/FilLexer.g4
@@ -28,6 +28,7 @@ VAR: 'var';
 VAL: 'val';
 TRUE: 'true';
 FALSE: 'false';
+NEW: 'new';
 
 // Operators
 EQ: '=';

--- a/src/grammar/FilLexer.g4
+++ b/src/grammar/FilLexer.g4
@@ -49,6 +49,7 @@ GT: '>';
 GTE: '>=';
 LPAREN: '(';
 RPAREN: ')';
+AMP: '&';
 
 // Assignation operators
 PLUS_EQ: '+=';

--- a/src/grammar/FilParser.g4
+++ b/src/grammar/FilParser.g4
@@ -67,6 +67,9 @@ expression returns[std::shared_ptr<filc::Expression> tree]
     | p=pointer {
         $tree = $p.tree;
     }
+    | po=pointer_operation {
+        $tree = $po.tree;
+    }
 
     // === Binary calcul ===
     | el3=expression op3=MOD er3=expression {
@@ -168,4 +171,9 @@ assignation returns[std::shared_ptr<filc::Assignation> tree]
 pointer returns[std::shared_ptr<filc::Pointer> tree]
     : NEW t=IDENTIFIER LPAREN e=expression RPAREN {
         $tree = std::make_shared<filc::Pointer>($t.text, $e.tree);
+    };
+
+pointer_operation returns[std::shared_ptr<filc::Expression> tree]
+    : STAR i=IDENTIFIER {
+        $tree = std::make_shared<filc::PointerDereferencing>($i.text);
     };

--- a/src/grammar/FilParser.g4
+++ b/src/grammar/FilParser.g4
@@ -176,4 +176,7 @@ pointer returns[std::shared_ptr<filc::Pointer> tree]
 pointer_operation returns[std::shared_ptr<filc::Expression> tree]
     : STAR i=IDENTIFIER {
         $tree = std::make_shared<filc::PointerDereferencing>($i.text);
+    }
+    | AMP i=IDENTIFIER {
+        $tree = std::make_shared<filc::VariableAddress>($i.text);
     };

--- a/src/grammar/pointer/Pointer.cpp
+++ b/src/grammar/pointer/Pointer.cpp
@@ -21,45 +21,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef FILC_DUMPVISITOR_H
-#define FILC_DUMPVISITOR_H
+#include "filc/grammar/pointer/Pointer.h"
 
-#include "filc/grammar/Visitor.h"
-#include <iostream>
+using namespace filc;
 
-namespace filc {
-class DumpVisitor final: public Visitor<void> {
-  public:
-    explicit DumpVisitor(std::ostream &out);
+Pointer::Pointer(std::string type_name, const std::shared_ptr<Expression> &value)
+    : _type_name(std::move(type_name)), _value(value) {}
 
-    auto visitProgram(Program *program) -> void override;
-
-    auto visitBooleanLiteral(BooleanLiteral *literal) -> void override;
-
-    auto visitIntegerLiteral(IntegerLiteral *literal) -> void override;
-
-    auto visitFloatLiteral(FloatLiteral *literal) -> void override;
-
-    auto visitCharacterLiteral(CharacterLiteral *literal) -> void override;
-
-    auto visitStringLiteral(StringLiteral *literal) -> void override;
-
-    auto visitVariableDeclaration(VariableDeclaration *variable) -> void override;
-
-    auto visitIdentifier(Identifier *identifier) -> void override;
-
-    auto visitBinaryCalcul(BinaryCalcul *calcul) -> void override;
-
-    auto visitAssignation(Assignation *assignation) -> void override;
-
-    auto visitPointer(Pointer *pointer) -> void override;
-
-  private:
-    std::ostream &_out;
-    int _indent_level;
-
-    auto printIdent() const -> void;
-};
+auto Pointer::getTypeName() const -> std::string {
+    return _type_name;
 }
 
-#endif // FILC_DUMPVISITOR_H
+auto Pointer::getValue() const -> std::shared_ptr<Expression> {
+    return _value;
+}
+
+auto Pointer::getPointedType() const -> std::shared_ptr<AbstractType> {
+    const auto type = std::dynamic_pointer_cast<PointerType>(getType());
+    if (type == nullptr) {
+        return nullptr;
+    }
+
+    return type->getPointedType();
+}
+
+auto Pointer::acceptVoidVisitor(Visitor<void> *visitor) -> void {
+    visitor->visitPointer(this);
+}
+
+auto Pointer::acceptIRVisitor(Visitor<llvm::Value *> *visitor) -> llvm::Value * {
+    return visitor->visitPointer(this);
+}

--- a/src/grammar/pointer/PointerDereferencing.cpp
+++ b/src/grammar/pointer/PointerDereferencing.cpp
@@ -21,42 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "test_tools.h"
+#include "filc/grammar/pointer/Pointer.h"
 
-#include <cstdlib>
-#include <filesystem>
-#include <fstream>
-#include <gtest/gtest.h>
+#include <utility>
 
-auto getProgramResult(const std::string &program) -> int {
-    std::ofstream program_file(FIXTURES_PATH "/ir_test.fil");
-    program_file << program;
-    program_file.flush();
-    program_file.close();
+using namespace filc;
 
-    const auto ir_output = run_with_args("--dump=ir " FIXTURES_PATH "/ir_test.fil 2>&1");
-    std::ofstream ir_file(FIXTURES_PATH "/ir_test.ir");
-    ir_file << ir_output;
-    ir_file.flush();
-    ir_file.close();
+PointerDereferencing::PointerDereferencing(std::string name): _name(std::move(name)) {}
 
-    const auto status = system("lli " FIXTURES_PATH "/ir_test.ir");
-
-    std::filesystem::remove(FIXTURES_PATH "/ir_test.fil");
-    std::filesystem::remove(FIXTURES_PATH "/ir_test.ir");
-
-    return WEXITSTATUS(status);
+auto PointerDereferencing::getName() const -> std::string {
+    return _name;
 }
 
-TEST(ir_dump, calcul_program) {
-    ASSERT_EQ(2, getProgramResult("1 + 1"));
-    ASSERT_EQ(5, getProgramResult("(3 * 2 + 4) / 2"));
+auto PointerDereferencing::acceptVoidVisitor(Visitor<void> *visitor) -> void {
+    visitor->visitPointerDereferencing(this);
 }
 
-TEST(ir_dump, variable_program) {
-    ASSERT_EQ(2, getProgramResult("val foo = 2\nfoo"));
-}
-
-TEST(ir_dump, pointer_program) {
-    ASSERT_EQ(3, getProgramResult("val foo = new i32(3);*foo"));
+auto PointerDereferencing::acceptIRVisitor(Visitor<llvm::Value *> *visitor) -> llvm::Value * {
+    return visitor->visitPointerDereferencing(this);
 }

--- a/src/grammar/pointer/VariableAddress.cpp
+++ b/src/grammar/pointer/VariableAddress.cpp
@@ -21,40 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef FILC_AST_H
-#define FILC_AST_H
+#include "filc/grammar/pointer/Pointer.h"
 
-namespace filc {
-class Program;
+#include <utility>
 
-class Expression;
+using namespace filc;
 
-template<typename T>
-class Literal;
+VariableAddress::VariableAddress(std::string name): _name(std::move(name)) {}
 
-class BooleanLiteral;
-
-class IntegerLiteral;
-
-class FloatLiteral;
-
-class CharacterLiteral;
-
-class StringLiteral;
-
-class VariableDeclaration;
-
-class Identifier;
-
-class BinaryCalcul;
-
-class Assignation;
-
-class Pointer;
-
-class PointerDereferencing;
-
-class VariableAddress;
+auto VariableAddress::getName() const -> std::string {
+    return _name;
 }
 
-#endif // FILC_AST_H
+auto VariableAddress::acceptVoidVisitor(Visitor<void> *visitor) -> void {
+    visitor->visitVariableAddress(this);
+}
+
+auto VariableAddress::acceptIRVisitor(Visitor<llvm::Value *> *visitor) -> llvm::Value * {
+    return visitor->visitVariableAddress(this);
+}

--- a/src/llvm/GeneratorContext.cpp
+++ b/src/llvm/GeneratorContext.cpp
@@ -21,36 +21,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef FILC_NAME_H
-#define FILC_NAME_H
+#include "filc/llvm/GeneratorContext.h"
 
-#include "filc/grammar/Type.h"
-#include <string>
-#include <memory>
+using namespace filc;
 
-namespace filc {
-class Name {
-  public:
-    Name();
+GeneratorContext::GeneratorContext() = default;
 
-    Name(bool constant, std::string name, std::shared_ptr<AbstractType> type, bool has_value);
-
-    [[nodiscard]] auto isConstant() const -> bool;
-
-    [[nodiscard]] auto hasValue() const -> bool;
-
-    [[nodiscard]] auto getName() const -> const std::string&;
-
-    [[nodiscard]] auto getType() const -> std::shared_ptr<AbstractType>;
-
-    auto hasValue(bool has_value) -> void;
-
-  private:
-    bool _constant;
-    bool _has_value;
-    std::string _name;
-    std::shared_ptr<AbstractType> _type;
-};
+auto GeneratorContext::setValue(const std::string &name, llvm::Value *value) -> void {
+    _values[name] = value;
 }
 
-#endif // FILC_NAME_H
+auto GeneratorContext::getValue(const std::string &name) const -> llvm::Value * {
+    if (_values.find(name) != _values.end()) {
+        return _values.at(name);
+    }
+    return nullptr;
+}

--- a/src/llvm/IRGenerator.cpp
+++ b/src/llvm/IRGenerator.cpp
@@ -27,11 +27,11 @@
 #include "filc/grammar/calcul/Calcul.h"
 #include "filc/grammar/identifier/Identifier.h"
 #include "filc/grammar/literal/Literal.h"
+#include "filc/grammar/pointer/Pointer.h"
 #include "filc/grammar/program/Program.h"
 #include "filc/grammar/variable/Variable.h"
 #include "filc/llvm/CalculBuilder.h"
 
-#include <filc/grammar/pointer/Pointer.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/MC/MCTargetOptions.h>
@@ -185,5 +185,14 @@ auto IRGenerator::visitPointer(Pointer *pointer) -> llvm::Value * {
     const auto alloca = _builder->CreateAlloca(pointer->getPointedType()->getLLVMType(_llvm_context.get()));
     _builder->CreateStore(pointer->getValue()->acceptIRVisitor(this), alloca);
 
-    return _builder->CreateLoad(pointer->getType()->getLLVMType(_llvm_context.get()), alloca);
+    return alloca;
+}
+
+auto IRGenerator::visitPointerDereferencing(PointerDereferencing *pointer) -> llvm::Value * {
+    const auto pointer_value = _context.getValue(pointer->getName());
+    if (pointer_value == nullptr) {
+        throw std::logic_error("Tried to access to a variable without a value set");
+    }
+
+    return _builder->CreateLoad(pointer->getType()->getLLVMType(_llvm_context.get()), pointer_value);
 }

--- a/src/llvm/IRGenerator.cpp
+++ b/src/llvm/IRGenerator.cpp
@@ -196,3 +196,11 @@ auto IRGenerator::visitPointerDereferencing(PointerDereferencing *pointer) -> ll
 
     return _builder->CreateLoad(pointer->getType()->getLLVMType(_llvm_context.get()), pointer_value);
 }
+
+auto IRGenerator::visitVariableAddress(VariableAddress *address) -> llvm::Value * {
+    const auto value  = _context.getValue(address->getName());
+    const auto alloca = _builder->CreateAlloca(value->getType());
+    _builder->CreateStore(value, alloca);
+
+    return alloca;
+}

--- a/src/validation/Environment.cpp
+++ b/src/validation/Environment.cpp
@@ -105,9 +105,16 @@ auto Environment::getName(const std::string &name) const -> const Name & {
     return _names.at(name);
 }
 
-auto Environment::addName(const filc::Name &name) -> void {
+auto Environment::addName(const Name &name) -> void {
     if (hasName(name.getName())) {
         throw std::logic_error("Environment already have name " + name.getName());
+    }
+    _names[name.getName()] = name;
+}
+
+auto Environment::setName(const Name &name) -> void {
+    if (! hasName(name.getName())) {
+        throw std::logic_error("Cannot change a name which does not exists: " + name.getName());
     }
     _names[name.getName()] = name;
 }

--- a/src/validation/Name.cpp
+++ b/src/validation/Name.cpp
@@ -27,13 +27,17 @@
 
 using namespace filc;
 
-Name::Name(): _constant(true) {}
+Name::Name(): _constant(true), _has_value(false) {}
 
-Name::Name(const bool constant, std::string name, std::shared_ptr<AbstractType> type)
-    : _constant(constant), _name(std::move(name)), _type(std::move(type)) {}
+Name::Name(const bool constant, std::string name, std::shared_ptr<AbstractType> type, const bool has_value)
+    : _constant(constant), _has_value(has_value), _name(std::move(name)), _type(std::move(type)) {}
 
 auto Name::isConstant() const -> bool {
     return _constant;
+}
+
+auto Name::hasValue() const -> bool {
+    return _has_value;
 }
 
 auto Name::getName() const -> const std::string & {
@@ -42,4 +46,8 @@ auto Name::getName() const -> const std::string & {
 
 auto Name::getType() const -> std::shared_ptr<AbstractType> {
     return _type;
+}
+
+auto Name::hasValue(const bool has_value) -> void {
+    _has_value = has_value;
 }

--- a/src/validation/ValidationVisitor.cpp
+++ b/src/validation/ValidationVisitor.cpp
@@ -350,3 +350,26 @@ auto ValidationVisitor::visitPointerDereferencing(PointerDereferencing *pointer)
         displayWarning("Value not used", pointer->getPosition());
     }
 }
+
+auto ValidationVisitor::visitVariableAddress(VariableAddress *address) -> void {
+    if (! _environment->hasName(address->getName())) {
+        displayError("Unknown name, don't know what it refers to: " + address->getName(), address->getPosition());
+        return;
+    }
+
+    const auto name                    = _environment->getName(address->getName());
+    const auto pointed_type            = name.getType();
+    std::shared_ptr<AbstractType> type = nullptr;
+    if (_environment->hasType(pointed_type->getName() + "*")) {
+        type = _environment->getType(pointed_type->getName() + "*");
+    } else {
+        type = std::make_shared<PointerType>(pointed_type);
+        _environment->addType(type);
+    }
+
+    address->setType(type);
+
+    if (! _context->has("return") || ! _context->get<bool>("return")) {
+        displayWarning("Value not used", address->getPosition());
+    }
+}

--- a/src/validation/ValidationVisitor.cpp
+++ b/src/validation/ValidationVisitor.cpp
@@ -330,3 +330,23 @@ auto ValidationVisitor::visitPointer(Pointer *pointer) -> void {
         displayWarning("Value not used", pointer->getPosition());
     }
 }
+
+auto ValidationVisitor::visitPointerDereferencing(PointerDereferencing *pointer) -> void {
+    if (! _environment->hasName(pointer->getName())) {
+        displayError("Unknown name, don't know what it refers to: " + pointer->getName(), pointer->getPosition());
+        return;
+    }
+
+    const auto name = _environment->getName(pointer->getName());
+    const auto type = std::dynamic_pointer_cast<PointerType>(name.getType());
+    if (type == nullptr) {
+        displayError("Cannot dereference a variable which is not a pointer", pointer->getPosition());
+        return;
+    }
+
+    pointer->setType(type->getPointedType());
+
+    if (! _context->has("return") || ! _context->get<bool>("return")) {
+        displayWarning("Value not used", pointer->getPosition());
+    }
+}

--- a/tests/unit/grammar/DumpVisitorTest.cpp
+++ b/tests/unit/grammar/DumpVisitorTest.cpp
@@ -198,3 +198,9 @@ TEST(DumpVisitor, PointerDereferencing) {
     ASSERT_THAT(dump, SizeIs(1));
     ASSERT_STREQ("[PointerDereferencing:foo]", dump[0].c_str());
 }
+
+TEST(DumpVisitor, VariableAddress) {
+    const auto dump = dumpProgram("&foo");
+    ASSERT_THAT(dump, SizeIs(1));
+    ASSERT_STREQ("[VariableAddress:foo]", dump[0].c_str());
+}

--- a/tests/unit/grammar/DumpVisitorTest.cpp
+++ b/tests/unit/grammar/DumpVisitorTest.cpp
@@ -62,7 +62,7 @@ TEST(DumpVisitor, dump) {
     std::stringstream ss;
     auto visitor = filc::DumpVisitor(ss);
     program->acceptVoidVisitor(&visitor);
-    std::string result(std::istreambuf_iterator<char>(ss), {});
+    const std::string result(std::istreambuf_iterator<char>(ss), {});
     ASSERT_STREQ("=== Begin AST dump ===\n=== End AST dump ===\n", result.c_str());
 }
 
@@ -117,7 +117,7 @@ TEST(DumpVisitor, visitCharacterLiteral_Classic) {
     filc::DumpVisitor visitor(ss);
     filc::CharacterLiteral literal('a');
     visitor.visitCharacterLiteral(&literal);
-    std::string dump(std::istreambuf_iterator<char>(ss), {});
+    const std::string dump(std::istreambuf_iterator<char>(ss), {});
     ASSERT_STREQ("[Character:'a']\n", dump.c_str());
 }
 
@@ -184,4 +184,17 @@ TEST(DumpVisitor, Assignation) {
     ASSERT_THAT(dump, SizeIs(2));
     ASSERT_STREQ("[Assignation:foo]", dump[0].c_str());
     ASSERT_STREQ("\t[Character:'a']", dump[1].c_str());
+}
+
+TEST(DumpVisitor, Pointer) {
+    const auto dump = dumpProgram("new i32(3)");
+    ASSERT_THAT(dump, SizeIs(2));
+    ASSERT_STREQ("[Pointer:i32]", dump[0].c_str());
+    ASSERT_STREQ("\t[Integer:3]", dump[1].c_str());
+}
+
+TEST(DumpVisitor, PointerDereferencing) {
+    const auto dump = dumpProgram("*foo");
+    ASSERT_THAT(dump, SizeIs(1));
+    ASSERT_STREQ("[PointerDereferencing:foo]", dump[0].c_str());
 }

--- a/tests/unit/grammar/TypeTest.cpp
+++ b/tests/unit/grammar/TypeTest.cpp
@@ -25,31 +25,36 @@
 #include <gtest/gtest.h>
 
 TEST(Type, getName) {
-    filc::Type type("my_type");
+    const filc::Type type("my_type");
     ASSERT_STREQ("my_type", type.getName().c_str());
 }
 
 TEST(Type, getDisplayName) {
-    filc::Type type("another_type");
+    const filc::Type type("another_type");
     ASSERT_STREQ("another_type", type.getDisplayName().c_str());
 }
 
 TEST(PointerType, getName) {
-    filc::PointerType type(std::make_shared<filc::Type>("int"));
+    const filc::PointerType type(std::make_shared<filc::Type>("int"));
     ASSERT_STREQ("int*", type.getName().c_str());
 }
 
 TEST(PointerType, getDisplayName) {
-    filc::PointerType type(std::make_shared<filc::Type>("int"));
+    const filc::PointerType type(std::make_shared<filc::Type>("int"));
     ASSERT_STREQ("int*", type.getDisplayName().c_str());
 }
 
+TEST(PonterType, getPointedType) {
+    const filc::PointerType type(std::make_shared<filc::Type>("int"));
+    ASSERT_STREQ("int", type.getPointedType()->getDisplayName().c_str());
+}
+
 TEST(AliasType, getName) {
-    filc::AliasType type("char", std::make_shared<filc::Type>("u8"));
+    const filc::AliasType type("char", std::make_shared<filc::Type>("u8"));
     ASSERT_STREQ("u8", type.getName().c_str());
 }
 
 TEST(AliasType, getDisplayName) {
-    filc::AliasType type("char", std::make_shared<filc::Type>("u8"));
+    const filc::AliasType type("char", std::make_shared<filc::Type>("u8"));
     ASSERT_STREQ("char", type.getDisplayName().c_str());
 }

--- a/tests/unit/grammar/pointer/PointerDereferencingTest.cpp
+++ b/tests/unit/grammar/pointer/PointerDereferencingTest.cpp
@@ -23,40 +23,17 @@
  */
 #include "test_tools.h"
 
-#include <cstdlib>
-#include <filesystem>
-#include <fstream>
+#include <filc/grammar/pointer/Pointer.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-auto getProgramResult(const std::string &program) -> int {
-    std::ofstream program_file(FIXTURES_PATH "/ir_test.fil");
-    program_file << program;
-    program_file.flush();
-    program_file.close();
+using namespace ::testing;
 
-    const auto ir_output = run_with_args("--dump=ir " FIXTURES_PATH "/ir_test.fil 2>&1");
-    std::ofstream ir_file(FIXTURES_PATH "/ir_test.ir");
-    ir_file << ir_output;
-    ir_file.flush();
-    ir_file.close();
-
-    const auto status = system("lli " FIXTURES_PATH "/ir_test.ir");
-
-    std::filesystem::remove(FIXTURES_PATH "/ir_test.fil");
-    std::filesystem::remove(FIXTURES_PATH "/ir_test.ir");
-
-    return WEXITSTATUS(status);
-}
-
-TEST(ir_dump, calcul_program) {
-    ASSERT_EQ(2, getProgramResult("1 + 1"));
-    ASSERT_EQ(5, getProgramResult("(3 * 2 + 4) / 2"));
-}
-
-TEST(ir_dump, variable_program) {
-    ASSERT_EQ(2, getProgramResult("val foo = 2\nfoo"));
-}
-
-TEST(ir_dump, pointer_program) {
-    ASSERT_EQ(3, getProgramResult("val foo = new i32(3);*foo"));
+TEST(PointerDereferencing, parsing) {
+    const auto program     = parseString("*foo");
+    const auto expressions = program->getExpressions();
+    ASSERT_THAT(expressions, SizeIs(1));
+    const auto pointer_dereferencing = std::dynamic_pointer_cast<filc::PointerDereferencing>(expressions[0]);
+    ASSERT_NE(nullptr, pointer_dereferencing);
+    ASSERT_STREQ("foo", pointer_dereferencing->getName().c_str());
 }

--- a/tests/unit/grammar/pointer/PointerTest.cpp
+++ b/tests/unit/grammar/pointer/PointerTest.cpp
@@ -21,45 +21,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef FILC_DUMPVISITOR_H
-#define FILC_DUMPVISITOR_H
+#include "test_tools.h"
 
-#include "filc/grammar/Visitor.h"
-#include <iostream>
+#include <filc/grammar/literal/Literal.h>
+#include <filc/grammar/pointer/Pointer.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
-namespace filc {
-class DumpVisitor final: public Visitor<void> {
-  public:
-    explicit DumpVisitor(std::ostream &out);
+using namespace ::testing;
 
-    auto visitProgram(Program *program) -> void override;
+TEST(Pointer, parsing) {
+    const auto program     = parseString("new i32(3)");
+    const auto expressions = program->getExpressions();
+    ASSERT_THAT(expressions, SizeIs(1));
+    const auto pointer = std::dynamic_pointer_cast<filc::Pointer>(expressions[0]);
+    ASSERT_NE(nullptr, pointer);
+    ASSERT_STREQ("i32", pointer->getTypeName().c_str());
 
-    auto visitBooleanLiteral(BooleanLiteral *literal) -> void override;
-
-    auto visitIntegerLiteral(IntegerLiteral *literal) -> void override;
-
-    auto visitFloatLiteral(FloatLiteral *literal) -> void override;
-
-    auto visitCharacterLiteral(CharacterLiteral *literal) -> void override;
-
-    auto visitStringLiteral(StringLiteral *literal) -> void override;
-
-    auto visitVariableDeclaration(VariableDeclaration *variable) -> void override;
-
-    auto visitIdentifier(Identifier *identifier) -> void override;
-
-    auto visitBinaryCalcul(BinaryCalcul *calcul) -> void override;
-
-    auto visitAssignation(Assignation *assignation) -> void override;
-
-    auto visitPointer(Pointer *pointer) -> void override;
-
-  private:
-    std::ostream &_out;
-    int _indent_level;
-
-    auto printIdent() const -> void;
-};
+    const auto value = std::dynamic_pointer_cast<filc::IntegerLiteral>(pointer->getValue());
+    ASSERT_NE(nullptr, value);
+    ASSERT_EQ(3, value->getValue());
 }
-
-#endif // FILC_DUMPVISITOR_H

--- a/tests/unit/llvm/IRGeneratorTest.cpp
+++ b/tests/unit/llvm/IRGeneratorTest.cpp
@@ -127,3 +127,10 @@ TEST(IRGenerator, pointerDereferencing_notThrow) {
     const auto ir = getIR("val foo = new i32(0);*foo");
     ASSERT_THAT(ir, HasSubstr("ret i32 %1")); // Register %1 contains pointed value
 }
+
+TEST(IRGenerator, variableAddress_notThrow) {
+    const auto ir = getIR("val foo = 0;val bar = &foo;*bar");
+    ASSERT_THAT(ir, HasSubstr("%0 = alloca i32"));
+    ASSERT_THAT(ir, HasSubstr("store i32 0, ptr %0")); // bar = &foo
+    ASSERT_THAT(ir, HasSubstr("ret i32 %1"));          // Register %1 is *foo
+}

--- a/tests/unit/llvm/IRGeneratorTest.cpp
+++ b/tests/unit/llvm/IRGeneratorTest.cpp
@@ -105,7 +105,7 @@ TEST(IRGenerator, variableDeclaration_value) {
 
 TEST(IRGenerator, variableDeclaration_identifier) {
     const auto ir = getIR("val foo = 2\nfoo");
-    ASSERT_THAT(ir, HasSubstr("ret i32 %0")); // Returns the register in which it loads the constant
+    ASSERT_THAT(ir, HasSubstr("ret i32 2")); // Returns the value directly
 }
 
 TEST(IRGenerator, calcul_integer) {

--- a/tests/unit/llvm/IRGeneratorTest.cpp
+++ b/tests/unit/llvm/IRGeneratorTest.cpp
@@ -22,13 +22,9 @@
  * SOFTWARE.
  */
 #include "filc/grammar/assignation/Assignation.h"
-#include "filc/grammar/calcul/Calcul.h"
-#include "filc/grammar/identifier/Identifier.h"
-#include "filc/grammar/variable/Variable.h"
 #include "filc/validation/ValidationVisitor.h"
 #include "test_tools.h"
 
-#include <filc/grammar/literal/Literal.h>
 #include <filc/grammar/program/Program.h>
 #include <filc/llvm/IRGenerator.h>
 #include <gmock/gmock.h>
@@ -125,4 +121,9 @@ TEST(IRGenerator, pointer_notThrow) {
     const auto ir = getIR("val foo = new i32(3);foo;0");
     ASSERT_THAT(ir, HasSubstr("alloca i32"));
     ASSERT_THAT(ir, HasSubstr("store i32 3, ptr %"));
+}
+
+TEST(IRGenerator, pointerDereferencing_notThrow) {
+    const auto ir = getIR("val foo = new i32(0);*foo");
+    ASSERT_THAT(ir, HasSubstr("ret i32 %1")); // Register %1 contains pointed value
 }

--- a/tests/unit/llvm/IRGeneratorTest.cpp
+++ b/tests/unit/llvm/IRGeneratorTest.cpp
@@ -120,3 +120,9 @@ TEST(IRGenerator, assignation_notThrow) {
     const auto ir = getIR("var bar = 3\nbar = 0");
     ASSERT_THAT(ir, HasSubstr("ret i32 0"));
 }
+
+TEST(IRGenerator, pointer_notThrow) {
+    const auto ir = getIR("val foo = new i32(3);foo;0");
+    ASSERT_THAT(ir, HasSubstr("alloca i32"));
+    ASSERT_THAT(ir, HasSubstr("store i32 3, ptr %"));
+}

--- a/tests/unit/test_tools.cpp
+++ b/tests/unit/test_tools.cpp
@@ -126,6 +126,10 @@ auto PrinterVisitor::visitPointer(filc::Pointer *pointer) -> void {
     _out << ")";
 }
 
+auto PrinterVisitor::visitPointerDereferencing(filc::PointerDereferencing *pointer) -> void {
+    _out << pointer->getName() << "*";
+}
+
 TokenSourceStub::TokenSourceStub(std::string filename): _filename(std::move(filename)) {}
 
 auto TokenSourceStub::nextToken() -> std::unique_ptr<antlr4::Token> {

--- a/tests/unit/test_tools.cpp
+++ b/tests/unit/test_tools.cpp
@@ -120,6 +120,12 @@ auto PrinterVisitor::visitAssignation(filc::Assignation *assignation) -> void {
     assignation->getValue()->acceptVoidVisitor(this);
 }
 
+auto PrinterVisitor::visitPointer(filc::Pointer *pointer) -> void {
+    _out << "new " << pointer->getTypeName() << "(";
+    pointer->getValue()->acceptVoidVisitor(this);
+    _out << ")";
+}
+
 TokenSourceStub::TokenSourceStub(std::string filename): _filename(std::move(filename)) {}
 
 auto TokenSourceStub::nextToken() -> std::unique_ptr<antlr4::Token> {

--- a/tests/unit/test_tools.cpp
+++ b/tests/unit/test_tools.cpp
@@ -127,7 +127,11 @@ auto PrinterVisitor::visitPointer(filc::Pointer *pointer) -> void {
 }
 
 auto PrinterVisitor::visitPointerDereferencing(filc::PointerDereferencing *pointer) -> void {
-    _out << pointer->getName() << "*";
+    _out << "*" << pointer->getName();
+}
+
+auto PrinterVisitor::visitVariableAddress(filc::VariableAddress *address) -> void {
+    _out << "&" << address->getName();
 }
 
 TokenSourceStub::TokenSourceStub(std::string filename): _filename(std::move(filename)) {}

--- a/tests/unit/test_tools.h
+++ b/tests/unit/test_tools.h
@@ -68,6 +68,8 @@ class PrinterVisitor final: public filc::Visitor<void> {
 
     auto visitPointerDereferencing(filc::PointerDereferencing *pointer) -> void override;
 
+    auto visitVariableAddress(filc::VariableAddress *address) -> void override;
+
   private:
     std::stringstream _out;
 };

--- a/tests/unit/test_tools.h
+++ b/tests/unit/test_tools.h
@@ -64,6 +64,8 @@ class PrinterVisitor final: public filc::Visitor<void> {
 
     auto visitAssignation(filc::Assignation *assignation) -> void override;
 
+    auto visitPointer(filc::Pointer *pointer) -> void override;
+
   private:
     std::stringstream _out;
 };

--- a/tests/unit/test_tools.h
+++ b/tests/unit/test_tools.h
@@ -66,6 +66,8 @@ class PrinterVisitor final: public filc::Visitor<void> {
 
     auto visitPointer(filc::Pointer *pointer) -> void override;
 
+    auto visitPointerDereferencing(filc::PointerDereferencing *pointer) -> void override;
+
   private:
     std::stringstream _out;
 };

--- a/tests/unit/validation/EnvironmentTest.cpp
+++ b/tests/unit/validation/EnvironmentTest.cpp
@@ -60,10 +60,25 @@ TEST(Environment, Name) {
     filc::Environment env;
     ASSERT_FALSE(env.hasName("my_name"));
     ASSERT_THROW(env.getName("my_name"), std::logic_error);
-    env.addName(filc::Name(false, "my_name", env.getType("i32")));
-    ASSERT_THROW(env.addName(filc::Name(true, "my_name", env.getType("i64"))), std::logic_error);
+    env.addName(filc::Name(false, "my_name", env.getType("i32"), true));
+    ASSERT_THROW(env.addName(filc::Name(true, "my_name", env.getType("i64"), true)), std::logic_error);
     ASSERT_TRUE(env.hasName("my_name"));
     ASSERT_FALSE(env.getName("my_name").isConstant());
     ASSERT_STREQ("my_name", env.getName("my_name").getName().c_str());
     ASSERT_STREQ("i32", env.getName("my_name").getType()->getName().c_str());
+}
+
+TEST(Environment, setName) {
+    filc::Environment env;
+    env.addName(filc::Name(false, "my_name", env.getType("i32"), true));
+    ASSERT_TRUE(env.hasName("my_name"));
+    ASSERT_FALSE(env.getName("my_name").isConstant());
+    ASSERT_STREQ("my_name", env.getName("my_name").getName().c_str());
+    ASSERT_STREQ("i32", env.getName("my_name").getType()->getName().c_str());
+    ASSERT_TRUE(env.getName("my_name").hasValue());
+    auto name = env.getName("my_name");
+    name.hasValue(false);
+    ASSERT_TRUE(env.getName("my_name").hasValue());
+    env.setName(name);
+    ASSERT_FALSE(env.getName("my_name").hasValue());
 }

--- a/tests/unit/validation/NameTest.cpp
+++ b/tests/unit/validation/NameTest.cpp
@@ -25,15 +25,26 @@
 #include <gtest/gtest.h>
 
 TEST(Name, defaultConstructor) {
-    filc::Name name;
+    const filc::Name name;
     ASSERT_TRUE(name.isConstant());
     ASSERT_STREQ("", name.getName().c_str());
     ASSERT_EQ(nullptr, name.getType());
+    ASSERT_FALSE(name.hasValue());
 }
 
 TEST(Name, constructor) {
-    filc::Name name(false, "my_var", std::make_shared<filc::Type>("i32"));
+    const filc::Name name(false, "my_var", std::make_shared<filc::Type>("i32"), true);
     ASSERT_FALSE(name.isConstant());
     ASSERT_STREQ("my_var", name.getName().c_str());
     ASSERT_STREQ("i32", name.getType()->getName().c_str());
+    ASSERT_TRUE(name.hasValue());
+}
+
+TEST(Name, setHasValue) {
+    filc::Name name(false, "my_var", std::make_shared<filc::Type>("i32"), false);
+    ASSERT_FALSE(name.hasValue());
+    name.hasValue(true);
+    ASSERT_TRUE(name.hasValue());
+    name.hasValue(false);
+    ASSERT_FALSE(name.hasValue());
 }

--- a/tests/unit/validation/ValidationVisitorTest.cpp
+++ b/tests/unit/validation/ValidationVisitorTest.cpp
@@ -39,7 +39,7 @@ TEST(ValidationVisitor, program_valid) {
     VISITOR;
     const auto program = parseString("0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
 }
 
@@ -47,9 +47,7 @@ TEST(ValidationVisitor, program_invalid) {
     VISITOR;
     const auto program = parseString("3.4");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("Expected type int aka i32 but got f64")
-    );
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Expected type int aka i32 but got f64"));
     ASSERT_TRUE(visitor.hasError());
 }
 
@@ -57,7 +55,7 @@ TEST(ValidationVisitor, program_finish_u8) {
     VISITOR;
     const auto program = parseString("val foo: u8 = 2\nfoo");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
 }
 
@@ -65,7 +63,7 @@ TEST(ValidationVisitor, program_finish_bool) {
     VISITOR;
     const auto program = parseString("true");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
 }
 
@@ -73,7 +71,7 @@ TEST(ValidationVisitor, boolean) {
     VISITOR;
     const auto program = parseString("true\n0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("Boolean value not used"));
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Boolean value not used"));
     ASSERT_FALSE(visitor.hasError());
 }
 
@@ -81,7 +79,7 @@ TEST(ValidationVisitor, integer) {
     VISITOR;
     const auto program = parseString("2\n0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("Integer value not used"));
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Integer value not used"));
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("int", program->getExpressions()[0]->getType()->getDisplayName().c_str());
 }
@@ -90,7 +88,7 @@ TEST(ValidationVisitor, float) {
     VISITOR;
     const auto program = parseString("3.14\n0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("Float value not used"));
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Float value not used"));
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("f64", program->getExpressions()[0]->getType()->getDisplayName().c_str());
 }
@@ -99,7 +97,7 @@ TEST(ValidationVisitor, character) {
     VISITOR;
     const auto program = parseString("'a'\n0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("Character value not used"));
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Character value not used"));
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("char", program->getExpressions()[0]->getType()->getDisplayName().c_str());
 }
@@ -108,7 +106,7 @@ TEST(ValidationVisitor, string) {
     VISITOR;
     const auto program = parseString("\"hello\"\n0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("String value not used"));
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("String value not used"));
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("char*", program->getExpressions()[0]->getType()->getDisplayName().c_str());
 }
@@ -117,7 +115,7 @@ TEST(ValidationVisitor, variable_alreadyDefined) {
     VISITOR;
     const auto program = parseString("val my_constant = 2\nval my_constant = 3");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("my_constant is already defined"));
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("my_constant is already defined"));
     ASSERT_TRUE(visitor.hasError());
     ASSERT_STREQ("int", program->getExpressions()[0]->getType()->getDisplayName().c_str());
     ASSERT_EQ(nullptr, program->getExpressions()[1]->getType());
@@ -128,7 +126,7 @@ TEST(ValidationVisitor, variable_constantWithoutValue) {
     const auto program = parseString("val my_constant");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
+        std::string(std::istreambuf_iterator(ss), {}),
         HasSubstr("When declaring a constant, you must provide it a value")
     );
     ASSERT_TRUE(visitor.hasError());
@@ -139,7 +137,7 @@ TEST(ValidationVisitor, variable_unknowType) {
     VISITOR;
     const auto program = parseString("var my_var: foo");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("Unknown type: foo"));
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Unknown type: foo"));
     ASSERT_TRUE(visitor.hasError());
     ASSERT_EQ(nullptr, program->getExpressions()[0]->getType());
 }
@@ -149,7 +147,7 @@ TEST(ValidationVisitor, variable_differentValueType) {
     const auto program = parseString("var my_var: i32 = 'a'");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
+        std::string(std::istreambuf_iterator(ss), {}),
         HasSubstr("Cannot assign value of type char aka u8 to a variable of type i32")
     );
     ASSERT_TRUE(visitor.hasError());
@@ -160,7 +158,7 @@ TEST(ValidationVisitor, variable_assignAliasType) {
     VISITOR;
     const auto program = parseString("var my_var: u8 = 'a'\n0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("u8", program->getExpressions()[0]->getType()->getDisplayName().c_str());
 }
@@ -170,7 +168,7 @@ TEST(ValidationVisitor, variable_withoutTypeAndValue) {
     const auto program = parseString("var my_var");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
+        std::string(std::istreambuf_iterator(ss), {}),
         HasSubstr("When declaring a variable, you must provide at least a type or a value")
     );
     ASSERT_TRUE(visitor.hasError());
@@ -181,7 +179,7 @@ TEST(ValidationVisitor, variable_valid) {
     VISITOR;
     const auto program = parseString("val foo: i32 = 45");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("i32", program->getExpressions()[0]->getType()->getDisplayName().c_str());
 }
@@ -190,7 +188,7 @@ TEST(ValidationVisitor, variable_castInteger) {
     VISITOR;
     const auto program = parseString("val bar: u8 = 4\n0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("u8", program->getExpressions()[0]->getType()->getDisplayName().c_str());
 }
@@ -200,18 +198,38 @@ TEST(ValidationVisitor, identifier_nonExisting) {
     const auto program = parseString("bar");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
-        HasSubstr("Unknown name, don't know what it refers to: bar")
+        std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Unknown name, don't know what it refers to: bar")
     );
     ASSERT_TRUE(visitor.hasError());
     ASSERT_EQ(nullptr, program->getExpressions()[0]->getType());
+}
+
+TEST(ValidationVisitor, identifier_noValue) {
+    VISITOR;
+    const auto program = parseString("var foo : i32\nfoo");
+    program->acceptVoidVisitor(&visitor);
+    ASSERT_THAT(
+        std::string(std::istreambuf_iterator(ss), {}),
+        HasSubstr("Variable foo has no value, please set one before accessing it")
+    );
+    ASSERT_TRUE(visitor.hasError());
+    ASSERT_EQ(nullptr, program->getExpressions()[1]->getType());
+}
+
+TEST(ValidationVisitor, identifier_validAssignation) {
+    VISITOR;
+    const auto program = parseString("var foo : i32\nfoo = 2\nfoo");
+    program->acceptVoidVisitor(&visitor);
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
+    ASSERT_FALSE(visitor.hasError());
+    ASSERT_STREQ("i32", program->getExpressions()[2]->getType()->getDisplayName().c_str());
 }
 
 TEST(ValidationVisitor, identifier_valid) {
     VISITOR;
     const auto program = parseString("val foo = 1\nfoo");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("int", program->getExpressions()[1]->getType()->getDisplayName().c_str());
 }
@@ -221,7 +239,7 @@ TEST(ValidationVisitor, calcul_invalidLeft) {
     const auto program = parseString("(val foo) + 2");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
+        std::string(std::istreambuf_iterator(ss), {}),
         HasSubstr("When declaring a constant, you must provide it a value")
     );
     ASSERT_TRUE(visitor.hasError());
@@ -233,7 +251,7 @@ TEST(ValidationVisitor, calcul_invalidRight) {
     const auto program = parseString("2 + (val foo)");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
+        std::string(std::istreambuf_iterator(ss), {}),
         HasSubstr("When declaring a constant, you must provide it a value")
     );
     ASSERT_TRUE(visitor.hasError());
@@ -245,7 +263,7 @@ TEST(ValidationVisitor, calcul_invalid) {
     const auto program = parseString("'a' && 3");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
+        std::string(std::istreambuf_iterator(ss), {}),
         HasSubstr("You cannot use operator && with char aka u8 and int aka i32")
     );
     ASSERT_TRUE(visitor.hasError());
@@ -256,7 +274,7 @@ TEST(ValidationVisitor, calcul_valid) {
     VISITOR;
     const auto program = parseString("2 + 2");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("int", program->getExpressions()[0]->getType()->getDisplayName().c_str());
 }
@@ -266,8 +284,7 @@ TEST(ValidationVisitor, assignation_nonExisting) {
     const auto program = parseString("foo = 3");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
-        HasSubstr("Unknown name, don't know what it refers to: foo")
+        std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Unknown name, don't know what it refers to: foo")
     );
     ASSERT_TRUE(visitor.hasError());
     ASSERT_EQ(nullptr, program->getExpressions()[0]->getType());
@@ -277,7 +294,7 @@ TEST(ValidationVisitor, assignation_constant) {
     VISITOR;
     const auto program = parseString("val foo = 3\nfoo = 4");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), HasSubstr("Cannot modify a constant"));
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Cannot modify a constant"));
     ASSERT_TRUE(visitor.hasError());
     ASSERT_EQ(nullptr, program->getExpressions()[1]->getType());
 }
@@ -287,7 +304,7 @@ TEST(ValidationVisitor, assignation_differentType) {
     const auto program = parseString("var foo = 3\nfoo = false");
     program->acceptVoidVisitor(&visitor);
     ASSERT_THAT(
-        std::string(std::istreambuf_iterator<char>(ss), {}),
+        std::string(std::istreambuf_iterator(ss), {}),
         HasSubstr("Cannot assign value of type bool to a variable of type int aka i32")
     );
     ASSERT_TRUE(visitor.hasError());
@@ -298,7 +315,7 @@ TEST(ValidationVisitor, assignation_valid) {
     VISITOR;
     const auto program = parseString("var foo = 3\nfoo = 2");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("int", program->getExpressions()[1]->getType()->getDisplayName().c_str());
 }
@@ -307,7 +324,7 @@ TEST(ValidationVisitor, assignation_castInteger) {
     VISITOR;
     const auto program = parseString("var foo: u8 = 3\nfoo = 2\n0");
     program->acceptVoidVisitor(&visitor);
-    ASSERT_THAT(std::string(std::istreambuf_iterator<char>(ss), {}), IsEmpty());
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("u8", program->getExpressions()[1]->getType()->getDisplayName().c_str());
 }

--- a/tests/unit/validation/ValidationVisitorTest.cpp
+++ b/tests/unit/validation/ValidationVisitorTest.cpp
@@ -396,3 +396,23 @@ TEST(ValidationVisitor, pointerDereferencing_valid) {
     ASSERT_FALSE(visitor.hasError());
     ASSERT_STREQ("i32", program->getExpressions()[1]->getType()->getName().c_str());
 }
+
+TEST(ValidationVisitor, variableAddress_unknown) {
+    VISITOR;
+    const auto program = parseString("&foo");
+    program->acceptVoidVisitor(&visitor);
+    ASSERT_THAT(
+        std::string(std::istreambuf_iterator(ss), {}), HasSubstr("Unknown name, don't know what it refers to: foo")
+    );
+    ASSERT_TRUE(visitor.hasError());
+}
+
+TEST(ValidationVisitor, variableAddress_valid) {
+    VISITOR;
+    const auto program = parseString("val foo = 2;val bar = &foo;*bar");
+    program->acceptVoidVisitor(&visitor);
+    ASSERT_THAT(std::string(std::istreambuf_iterator(ss), {}), IsEmpty());
+    ASSERT_FALSE(visitor.hasError());
+    ASSERT_STREQ("i32*", program->getExpressions()[1]->getType()->getName().c_str());
+    ASSERT_STREQ("i32", program->getExpressions()[2]->getType()->getName().c_str());
+}


### PR DESCRIPTION
Closes #51

Introduce `new` keyword to be able to `new i32(25)` for example.

Also add pointer dereferencing `*` and variable address `&`.